### PR TITLE
chore(ci): run tests on push and refactor

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,20 @@
+name: tests
+
+on: [push]
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.7"
+      - name: Install redis
+        run: sudo apt-get install -y redis-tools redis-server
+      - name: Verify that redis is up
+        run: redis-cli ping
+      - name: Run tests
+        run: |
+          pip install -r requirements.txt
+          python run-tests.py

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -14,7 +14,7 @@ jobs:
         run: sudo apt-get install -y redis-tools redis-server
       - name: Verify that redis is up
         run: redis-cli ping
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Run tests
-        run: |
-          pip install -r requirements.txt
-          python run-tests.py
+        run: python run-tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ aiocron
 croniter
 
 # Human-readable time deltas
-humanize
+humanize==3.5.0
 
 # Telegram BOT
 python-telegram-bot

--- a/run-tests.py
+++ b/run-tests.py
@@ -1,32 +1,27 @@
 #!/usr/bin/env python
-import os
 import sys
+import unittest
 
+from pathlib import Path
 
-if __name__ == '__main__':
-    src_dirpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'src')
-    sys.path.append(src_dirpath)
-    import unittest
+def main():
+    """Set up environment and use unit tests built-in discovery."""
+    src_dir = Path(__file__).parent / 'src'
+    sys.path.insert(0, str(src_dir))
+
     from aggregator.clock import set_local_timezone_to_utc
     set_local_timezone_to_utc()
-    test_loader = unittest.defaultTestLoader
-    test_runner = unittest.TextTestRunner()
-    package_directories = [os.path.join(src_dirpath, 'aggregator')]
-    test_suites = [test_loader.discover(pkg_dir, pattern='*_tests.py', top_level_dir=src_dirpath) for pkg_dir in package_directories]
-    combined_suite = unittest.TestSuite()
-    for suite in test_suites:
-        combined_suite.addTest(suite)
-    result = test_runner.run(combined_suite)
 
-    # Debug output to validate result object
-    print("\nTest Result Debug Info:")
-    print(f"Type: {type(result)}")
-    print(f"wasSuccessful(): {result.wasSuccessful()}")
-    print(f"Tests run: {result.testsRun}")
-    print(f"Failures: {len(result.failures)}")
-    print(f"Errors: {len(result.errors)}")
-    print(f"Skipped: {len(result.skipped)}")
+    # Use unittest
+    sys.argv = [
+        'unittest', 'discover',
+        '-s', str(src_dir),
+        '-p', '*_tests.py',
+        '-t', str(src_dir),
+        '-v'
+    ]
 
-    exit_code = 0 if result.wasSuccessful() else 1
-    print(f"Exit code: {exit_code}")
-    sys.exit(exit_code)
+    unittest.main(module=None)
+
+if __name__ == '__main__':
+    main()

--- a/run-tests.py
+++ b/run-tests.py
@@ -13,4 +13,20 @@ if __name__ == '__main__':
     test_runner = unittest.TextTestRunner()
     package_directories = [os.path.join(src_dirpath, 'aggregator')]
     test_suites = [test_loader.discover(pkg_dir, pattern='*_tests.py', top_level_dir=src_dirpath) for pkg_dir in package_directories]
-    test_runner.run(unittest.TestSuite(test_suites))
+    combined_suite = unittest.TestSuite()
+    for suite in test_suites:
+        combined_suite.addTest(suite)
+    result = test_runner.run(combined_suite)
+
+    # Debug output to validate result object
+    print("\nTest Result Debug Info:")
+    print(f"Type: {type(result)}")
+    print(f"wasSuccessful(): {result.wasSuccessful()}")
+    print(f"Tests run: {result.testsRun}")
+    print(f"Failures: {len(result.failures)}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Skipped: {len(result.skipped)}")
+
+    exit_code = 0 if result.wasSuccessful() else 1
+    print(f"Exit code: {exit_code}")
+    sys.exit(exit_code)


### PR DESCRIPTION
This PR introduces automated testing via GitHub Actions and modernizes the test runner infrastructure.

## Changes

* Added GitHub Actions workflow that runs on every push
* Configured Ubuntu 22.04 environment with Python 3.7 (20.04 is no longer available)
* Installs Redis installation and verification
* Refactored run-tests.py to use unittest's built-in discovery mechanism
* Added verbose test output for better debugging
* Pinned humanize to version 3.5.0 for consistent builds, 4.x seems to break our current tests
